### PR TITLE
Header & footer cleanup

### DIFF
--- a/views/_partials/footer.hbs
+++ b/views/_partials/footer.hbs
@@ -2,23 +2,20 @@
 
 		{{#if JS}}
 		<script>
-		function downloadJSAtOnload() {
-			var element = document.createElement("script");
-			element.src = "_client/scripts/bundle.js";
-			document.body.appendChild(element);
-		}
-		if (window.addEventListener){
-			window.addEventListener("load", downloadJSAtOnload, false);
-		}else if (window.attachEvent) {
-			window.attachEvent("onload", downloadJSAtOnload);
-		}else {
-			window.onload = downloadJSAtOnload;
-		}
-	</script>
-	{{/if}}
-	
-	</body>
+			function downloadJSAtOnload() {
+				var element = document.createElement('script');
+				element.src = '_client/scripts/bundle.js';
+				document.body.appendChild(element);
+			}
 
-	
-	 
+			if (window.addEventListener){
+				window.addEventListener('load', downloadJSAtOnload, false);
+			} else if (window.attachEvent) {
+				window.attachEvent('onload', downloadJSAtOnload);
+			} else {
+				window.onload = downloadJSAtOnload;
+			}
+		</script>
+		{{/if}}
+	</body>
 </html>

--- a/views/_partials/header.hbs
+++ b/views/_partials/header.hbs
@@ -1,27 +1,38 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 	<head>
-		<title>Static website generator</title>
 		<meta charset="utf-8">
+		<meta name="language" content="en">
 		<meta http-equiv="content-language" content="en" />
-		<script type="text/javascript" src="_client/scripts/critical-bundle.js"></script>
-		
-	  	<link rel="icon" href="_client/images/global/favicon.ico" type="image/x-icon">
-	  	<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	  	<!--[if IE 8]>
+		<title>Static website generator</title>
+		<meta name="description" content="" />
+
+		<meta property="og:title" content="">
+		<meta property="og:type" content="website">
+		<meta property="og:url" content="">
+		<meta property="og:image" content="">
+		<meta property="og:site_name" content="">
+		<meta property="og:description" content="">
+
+		<meta name="google-site-verification" content="">
+
+		<link rel="icon" href="_client/images/global/favicon.ico" type="image/x-icon">
+
+		<!--[if IE 8]>
 	  		<link rel="stylesheet" href="/_client/styles/ie8.css" />
 	  		<script async type="text/javascript" src="/_client/scripts/ie.js"></script>
 	  	<![endif]-->
 
-	  	<!--[if IE 9]>
+		<!--[if IE 9]>
 	  		<link rel="stylesheet" href="/_client/styles/main.css" type="text/css" />
 	  	<![endif]-->
-	  	
-	  	<!--[if  !IE]><!-->
-	  		<link rel="stylesheet" href="/_client/styles/main.css" type="text/css" />
-	  	<!--<![endif]-->
 
+		<!--[if  !IE]><!-->
+			<link rel="stylesheet" href="/_client/styles/main.css" type="text/css" />
+		<!--<![endif]-->
+		<script type="text/javascript" src="_client/scripts/critical-bundle.js"></script>
 	</head>
 	<body>
 		{{> site-header/site-header }}


### PR DESCRIPTION
Sorted out the mixed whitespace, added missing meta tags that will be used on most projects, moved the critical JS down to below the styles to prevent them being render blocked.

If the critical js is intended to be things like modernizr and html5 shiv etc then there are cases where it needs to be above the styles. However currently it would include things like jQuery which we really don't want to be before the styles.

An idea might be to split the vendor js directory out to polyfils as well. Things in polyfils need to be in the head to make browsers work with the code we have. Everything else can be loaded just before the closing body tag