### PR TITLE
Fix paths for components so that watch functions correctly

### DIFF
--- a/_config/paths.js
+++ b/_config/paths.js
@@ -5,7 +5,7 @@ function getConfig(paths) {
 
 	var config =  {
 		src: {
-			components: paths.dirs.components,
+			components: paths.dirs.components + _DIR,
 			fonts:      paths.src + _DIR + paths.dirs.fonts + _DIR,
 			images:     paths.src + _DIR + paths.dirs.images + _DIR,
 			scripts:    paths.src + _DIR + paths.dirs.scripts + _DIR,

--- a/gulpTasks/styles.js
+++ b/gulpTasks/styles.js
@@ -36,7 +36,7 @@ module.exports = function(gulp, config, argv) {
 
     var sassConfig = {
         errLogToConsole: true,
-        includePaths:    [config.dirs.components],
+        includePaths:    [config.paths.src.components],
         outputStyle:     'compact'
     };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,7 @@ require('./gulpTasks/local-testing.js')(gulp, config);
 gulp.task('watch:sass', function () {
 	if(!argv.prod) {
 		gulp.watch(
-			[config.paths.src.styles + '**/*.scss', config.dirs.components + '**/*.scss'],
+			[config.paths.src.styles + '**/*.scss', config.paths.src.components + '**/*.scss'],
 			['sass']
 		);
 	}
@@ -45,7 +45,7 @@ gulp.task('watch:sass', function () {
 gulp.task('watch:js', function () {
 	if(!argv.prod) {
 		gulp.watch(
-			[config.paths.src.scripts + '**/*.js', config.dirs.components + '/**/*.js'],
+			[config.paths.src.scripts + '**/*.js', config.paths.src.components + '/**/*.js'],
 			['scripts']
 		);
 	}


### PR DESCRIPTION
The component path was missing a final '/' so was breaking when specifying files within it.