### PR TITLE
Add dev task to avoid needing two terminal windows open while developing

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,6 +67,10 @@ gulp.task('serve', function(cb) {
 	runSeq(['localServer'], ['browser-sync'], cb);
 });
 
+gulp.task('dev', function(cb) {
+	runSeq(['default'], ['watch', 'serve'], cb);
+});
+
 gulp.task('default', function (cb) {
 	runSeq(['sass-generate-contents'],['sass', 'scripts','scripts:vendor' ,'scripts:ie' ,'copy:fonts', 'imagemin'], ['sass:legacy:ie8'], cb);
 });


### PR DESCRIPTION
Was getting annoyed with needing two terminal windows with `gulp serve` and `gulp watch` running in order to develop.

Just adds a task `gulp dev` that runs both. If you guys are happy i'll add info to the readme.

@tawashley @andrewbrandwood @furzeface 