### PR TITLE
Handlebars improvements

### DIFF
--- a/_config/handlebars.json
+++ b/_config/handlebars.json
@@ -3,8 +3,8 @@
 		"./views/_partials"
 	],
 	"views" : [
-        "./views/*.hbs"
-        ,"./views/**/*.hbs"
-        ,"!./views/_partials/**"
-    ]
+		"./views/*.hbs",
+		"./views/**/*.hbs",
+		"!./views/_partials/**"
+	]
 }

--- a/_config/project.json
+++ b/_config/project.json
@@ -1,15 +1,15 @@
 {
-	"dest": "public/_client",
-	"src": "_source",
-    "build": "build/_client",
+	"dest":  "public/_client",
+	"src":   "_source",
+	"build": "build/_client",
 	"dirs": {
-        "styles":     	"styles",
-        "scripts":    	"scripts",
-        "images":     	"images",
-        "components": 	"views",
-        "fonts": 	"fonts",
-        "reports": 		"reports"
-    },
-    "pixelBase": "16px",
-    "pixelBaseNoUnit": 16
+		"styles":     "styles",
+		"scripts":    "scripts",
+		"images":     "images",
+		"components": "views",
+		"fonts":      "fonts",
+		"reports":    "reports"
+	},
+	"pixelBase": "16px",
+	"pixelBaseNoUnit": 16
 }

--- a/_config/templateData.json
+++ b/_config/templateData.json
@@ -1,3 +1,15 @@
 {
-    "styleguideHeading": "Styleguide heading"
+	"meta": {
+		"title":              "Static website generator",
+		"googleVerification": "wefwefwe",
+		"og": {
+			"title":       "Static website generator",
+			"name":        "Static website",
+			"url":         "http://localhost:3001",
+			"image":       "http://placehold.it/300x300",
+			"site_name":   "Static website generator",
+			"description": "sdfsfsdf",
+			"type":        "website"
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.0.2",
     "karma-phantomjs-launcher": "^0.2.0",
+    "merge": "^1.2.0",
     "mocha": "^2.3.3",
     "phantomjs": "^1.9.17"
   }

--- a/routes/main.js
+++ b/routes/main.js
@@ -1,5 +1,6 @@
-var path = require('path');
-var templateData = require(path.resolve(__dirname, '..', '_config', 'templateData.json'));
+var path            = require('path');
+var merge           = require('merge');
+var defaultData     = require(path.resolve(__dirname, '..', '_config', 'templateData.json'));
 var templateHelpers = require(path.resolve(__dirname, '..', '_config', 'templateHelpers.js'))();
 
 var WebsiteController = function (website) {
@@ -8,14 +9,27 @@ var WebsiteController = function (website) {
 	this.get = function(request, response) {
 		if (!request.body) return response.sendStatus(400);
 		var url = parseUrl(request.params[0]);
-		
-		response.render(url, createModel());
+
+		response.render(url, createModel(url));
 	};
 
-	function createModel(params){
+	function getData(file) {
+		var templateData;
+
+		try{
+			templateData = require(path.resolve(__dirname, '..', 'views/_data', file + '.json'));
+		} catch(err){
+			templateData = {};
+		}
+
+		templateData = merge(defaultData, templateData);
+
+		return templateData;
+	}
+
+	function createModel(partialName){
 		var model = {
-			layout: false,
-			data: templateData,
+			data:    getData(partialName),
 			helpers: templateHelpers
 		}
 

--- a/routing.js
+++ b/routing.js
@@ -3,9 +3,9 @@ var fileSystem = require('fs');
 module.exports = function(website){
 	fileSystem.readdirSync(__dirname + '/routes').forEach(function(file){
 		if (file[0] === '.' || file.match(/^(Roco|environment|routes|autoload)\.(js|coffee|json|yml|yaml)$/)) {
-    	return;
-    }
-    var filePath = './routes/' + file;
+		return;
+	}
+	var filePath = './routes/' + file;
 		require(filePath)(website);
 	});
 };

--- a/views/_data/styleguide.json
+++ b/views/_data/styleguide.json
@@ -1,0 +1,9 @@
+{
+	"meta": {
+		"title": "Styleguide",
+		"og": {
+			"title": "Styleguide"
+		}
+	},
+	"heading": "Styleguide heading"
+}

--- a/views/_layouts/main.hbs
+++ b/views/_layouts/main.hbs
@@ -1,0 +1,5 @@
+{{> header }}
+{{> site-header/site-header }}
+{{{body}}}
+{{> site-footer/site-footer}}
+{{> footer }}

--- a/views/_partials/header.hbs
+++ b/views/_partials/header.hbs
@@ -6,17 +6,17 @@
 		<meta http-equiv="content-language" content="en" />
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-		<title>Static website generator</title>
+		<title>{{data.meta.title}}</title>
 		<meta name="description" content="" />
 
-		<meta property="og:title" content="">
-		<meta property="og:type" content="website">
-		<meta property="og:url" content="">
-		<meta property="og:image" content="">
-		<meta property="og:site_name" content="">
-		<meta property="og:description" content="">
+		<meta property="og:title" content="{{data.meta.og.title}}">
+		<meta property="og:type" content="{{data.meta.og.type}}">
+		<meta property="og:url" content="{{data.meta.og.url}}">
+		<meta property="og:image" content="{{data.meta.og.image}}">
+		<meta property="og:site_name" content="{{data.meta.og.site_name}}">
+		<meta property="og:description" content="{{data.meta.og.description}}">
 
-		<meta name="google-site-verification" content="">
+		<meta name="google-site-verification" content="{{data.meta.googleVerification}}">
 
 		<link rel="icon" href="_client/images/favicons/favicon.ico" type="image/x-icon">
 

--- a/views/_partials/header.hbs
+++ b/views/_partials/header.hbs
@@ -35,4 +35,3 @@
 		<script type="text/javascript" src="_client/scripts/bundle-critical.js"></script>
 	</head>
 	<body>
-		{{> site-header/site-header }}

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -1,9 +1,5 @@
-{{> header}}
-
 <div class="wrapper">
     <h1>Hello World!</h1>
     <h2>A winner is you!</h2>
     <a href="/styleguide">Show me the styleguide</a>
 </div>
-
-{{> footer JS=true}}

--- a/views/styleguide.hbs
+++ b/views/styleguide.hbs
@@ -1,4 +1,3 @@
-{{> header}}
 	<!-- start site markup -->
 	<div class="styleguide">
 		<div class="wrapper">
@@ -71,4 +70,3 @@
 	</div>
 
 	<!-- / end site markup -->
-{{> footer JS=true}}

--- a/website.js
+++ b/website.js
@@ -1,34 +1,36 @@
-var express = require('express'),
-	website = express(),
-	http = require('http').Server(website),
-	path = require('path'),
-	logger = require('express-logger'),
-	json = require('express-json'),
-	bodyParser = require('body-parser'),
-	expressSession = require('express-session'),
-	methodOverride = require('express-method-override'),
-	exphbs = require('express-handlebars'),
-	chalk = require('chalk');
+var express        = require('express');
+var website        = express();
+var http           = require('http').Server(website);
+var path           = require('path');
+var logger         = require('express-logger');
+var json           = require('express-json');
+var bodyParser     = require('body-parser');
+var expressSession = require('express-session');
+var methodOverride = require('express-method-override');
+var exphbs         = require('express-handlebars');
+var chalk          = require('chalk');
 
 website.engine('hbs', exphbs({
-	extname:'hbs',
-	defaultLayout:'index.hbs',
-	partialsDir: ['views/_partials']
+	extname:       'hbs',
+	defaultLayout: 'index.hbs',
+	layoutsDir:    'views/_layouts',
+	defaultLayout: 'main',
+	partialsDir:   ['views/_partials']
 }));
 
 website.set('port', process.env.PORT || 3001);
 website.set('views', path.join(__dirname, 'views'));
 website.set('view engine', 'hbs');
 website.use(logger({path: './logs/logfile.txt'}));
-website.use(expressSession({secret: '18dhN7skw9AY82jb',
-                 saveUninitialized: true,
-                 resave: true}));
+website.use(expressSession({
+	secret:            '18dhN7skw9AY82jb',
+	saveUninitialized: true,
+	resave:            true
+}));
 website.use(json());
 website.use(bodyParser.urlencoded({ extended: false }));
 website.use(methodOverride());
 website.use(express.static(path.join(__dirname, 'public')));
-
-
 
 // Setup routing
 require('./routing')(website);


### PR DESCRIPTION
## Not ready to merge yet!

I have started to upgrade the way that data is loaded into the templates so that we aren't restricted to one JSON file for all pages. That quickly becomes unsustainable, for example the Brother static site has grown to 111 pages.

I have updated the views directory to the following structure:
*views/_data*
*views/_layouts*
*views/_partials*

Within `views/_data` you add JSON files named for the pages they are used for. E.g `styleguide.hbs` has a related `styleguide.json` to pull data from. `_config/_templateData.json` is still used but as a default which is extended by the page specific files. 

Having a page specific file is optional, the default data will be used if nothing is found. This makes it much easier to set page titles etc without `_config/templateData.json` becoming unwieldy.

The second major change is to get the project using the handlebars layouts. This simplifies the page code while still allowing us to have pages with different layouts. I'm unsure if not using them was an intentional choice in the first place.

I still have to change the compiled templates to make use of this and update the config so that it is shared between the two.

I would suggest a further change of moving the pages into `views/_pages` rather than just being in `views`. Once you start adding a few pages, especially within directories it becomes unwieldy pretty quickly having them in the root.

Thouths @andrewbrandwood @tawashley @furzeface 